### PR TITLE
feat: create id commitment from cryptkeeper if no active id yet

### DIFF
--- a/src/ducks/zkpr.test.ts
+++ b/src/ducks/zkpr.test.ts
@@ -23,14 +23,8 @@ describe('ZKPR duck', () => {
       })
     );
     // @ts-ignore
-    const id = await store.dispatch(connectZKPR());
-    expect(id).toStrictEqual({
-      type: 'zkpr_interrep',
-      provider: 'diamond',
-      name: 'Twitter',
-      identityPath: { path_elements: ['1', '2'], path_index: [0, 2], root: '3' },
-      identityCommitment: '291',
-    });
+    await store.dispatch(connectZKPR());
+    expect(store.getState().zkpr.idCommitment).toBe('291');
 
     const onLogout = zkprStub.on.args[0][1];
     const onIdentityChanged = zkprStub.on.args[1][1];

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -36,6 +36,14 @@ type State = {
   idCommitment: string;
 };
 
+declare global {
+  interface Window {
+    zkpr?: {
+      connect: () => Promise<Client | null>;
+    };
+  }
+}
+
 const initialState: State = {
   zkpr: null,
   idCommitment: '',
@@ -63,9 +71,7 @@ export const connectZKPR =
     try {
       let id: Identity | null = null;
 
-      // @ts-ignore
       if (typeof window.zkpr !== 'undefined') {
-        // @ts-ignore
         const zkpr: any = window.zkpr;
         const client = await zkpr.connect();
         const zkprClient = new ZKPR(client);

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -13,6 +13,7 @@ import {
   SemaphoreFullProof,
   SemaphoreSolidityProof,
 } from '@zk-kit/protocols';
+import { hexlify } from '~/crypto';
 
 enum ActionTypes {
   SET_LOADING = 'zkpr/setLoading',
@@ -231,7 +232,8 @@ export class ZKPR {
   }
 
   async getActiveIdentity(): Promise<string | null> {
-    return this.client.getActiveIdentity();
+    const id = await this.client.getActiveIdentity();
+    return hexlify(id);
   }
 
   async createIdentity(): Promise<void> {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -128,7 +128,10 @@ export const createZKPRIdentity =
 
 export async function maybeSetZKPRIdentity(idCommitment: string) {
   let id: Identity | null = null;
-  const data = await checkPath(idCommitment);
+  const data = await checkPath(idCommitment).catch(err => {
+    console.error(err);
+    return null;
+  });
 
   if (data) {
     id = {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -115,6 +115,7 @@ export const createZKPRIdentity =
 
 export async function maybeSetZKPRIdentity(idCommitment: string) {
   let id: Identity | null = null;
+  // TODO: address https://github.com/zkitter/ui/pull/127#discussion_r1160318853
   const data = await checkPath(idCommitment).catch(err => {
     console.error(err);
     return null;

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -13,7 +13,7 @@ import {
   SemaphoreFullProof,
   SemaphoreSolidityProof,
 } from '@zk-kit/protocols';
-import { hexlify } from '~/crypto';
+import { hexify } from '~/format';
 
 enum ActionTypes {
   SET_LOADING = 'zkpr/setLoading',
@@ -75,7 +75,7 @@ export const connectZKPR =
           dispatch(setIdCommitment(''));
 
           if (idCommitment) {
-            idCommitment = idCommitment?.startsWith('0x') ? idCommitment : hexlify(idCommitment);
+            idCommitment = idCommitment?.startsWith('0x') ? idCommitment : hexify(idCommitment);
             dispatch(setIdCommitment(idCommitment));
             const _id: any = await maybeSetZKPRIdentity(idCommitment);
             if (!_id) setDefaultIdentity(defaultIdSelector(getState()));
@@ -237,7 +237,7 @@ export class ZKPR {
 
   async getActiveIdentity(): Promise<string | null> {
     const id = await this.client.getActiveIdentity();
-    return id ? hexlify(id) : null;
+    return id ? hexify(id) : null;
   }
 
   async createIdentity(): Promise<void> {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -51,15 +51,6 @@ const initialState: State = {
   unlocking: false,
 };
 
-const defaultIdSelector = (state: AppRootState): string | null => {
-  const defaultId = state.worker?.identities?.[0];
-  return defaultId !== undefined
-    ? defaultId?.type === 'gun'
-      ? defaultId.publicKey
-      : defaultId?.identityCommitment
-    : null;
-};
-
 const setDefaultIdentity = (defaultId: string | null) => {
   postWorkerMessage(defaultId === null ? setIdentity(defaultId) : selectIdentity(defaultId));
 };
@@ -199,6 +190,15 @@ export default function zkpr(state = initialState, action: Action<any>): State {
       return state;
   }
 }
+
+const defaultIdSelector = (state: AppRootState): string | null => {
+  const defaultId = state.worker?.identities?.[0];
+  return defaultId !== undefined
+    ? defaultId?.type === 'gun'
+      ? defaultId.publicKey
+      : defaultId?.identityCommitment
+    : null;
+};
 
 export const useZKPRLoading = () => {
   return useSelector((state: AppRootState) => {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -71,6 +71,7 @@ export const connectZKPR =
         });
 
         zkprClient.on('identityChanged', async idCommitment => {
+          // TODO: update once event data if { idCommitment, provider }
           dispatch(setIdCommitment(''));
 
           if (idCommitment) {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -91,8 +91,7 @@ export const connectZKPR =
 
         localStorage.setItem('ZKPR_CACHED', '1');
 
-        const idCommitmentHex = await zkprClient.getActiveIdentity();
-        const idCommitment = idCommitmentHex && BigInt('0x' + idCommitmentHex).toString();
+        const idCommitment = await zkprClient.getActiveOrCreateIdentity();
 
         if (idCommitment) {
           dispatch(setIdCommitment(idCommitment));
@@ -237,6 +236,16 @@ export class ZKPR {
 
   async createIdentity(): Promise<void> {
     return this.client.createIdentity();
+  }
+
+  async getActiveOrCreateIdentity(): Promise<string | null> {
+    const id = await this.getActiveIdentity();
+    if (id) {
+      return id;
+    } else {
+      await this.createIdentity();
+      return await this.getActiveIdentity();
+    }
   }
 
   async semaphoreProof(

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -84,9 +84,7 @@ export const connectZKPR =
           dispatch(setIdCommitment(''));
 
           if (idCommitment) {
-            // @ts-ignore
             dispatch(setIdCommitment(idCommitment));
-            // @ts-ignore
             const id: any = await maybeSetZKPRIdentity(idCommitment);
             if (!id) {
               const [defaultId] = identities;
@@ -229,6 +227,11 @@ export const useIdCommitment = () => {
   }, deepEqual);
 };
 
+interface ZKPRListener {
+  logout: () => void;
+  identityChanged: (data: { idCommitment: string; provider: string }) => void;
+}
+
 export class ZKPR {
   private client: any;
 
@@ -236,8 +239,8 @@ export class ZKPR {
     this.client = client;
   }
 
-  on(eventName: string, cb: (data: unknown) => void) {
-    return this.client.on(eventName, cb);
+  on<U extends keyof ZKPRListener>(event: U, listener: ZKPRListener[U]) {
+    return this.client.on(event, listener);
   }
 
   async getActiveIdentity(): Promise<string | null> {

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -64,15 +64,7 @@ export const connectZKPR =
           dispatch(disconnectZKPR());
 
           const [defaultId] = identities;
-          if (defaultId) {
-            postWorkerMessage(
-              selectIdentity(
-                defaultId.type === 'gun' ? defaultId.publicKey : defaultId.identityCommitment
-              )
-            );
-          } else {
-            postWorkerMessage(setIdentity(null));
-          }
+          setDefaultIdentity(defaultId);
         });
 
         zkprClient.on('identityChanged', async data => {
@@ -88,15 +80,7 @@ export const connectZKPR =
             const id: any = await maybeSetZKPRIdentity(idCommitment);
             if (!id) {
               const [defaultId] = identities;
-              if (defaultId) {
-                postWorkerMessage(
-                  selectIdentity(
-                    defaultId.type === 'gun' ? defaultId.publicKey : defaultId.identityCommitment
-                  )
-                );
-              } else {
-                postWorkerMessage(setIdentity(null));
-              }
+              setDefaultIdentity(defaultId);
             }
           }
         });

--- a/src/ducks/zkpr.ts
+++ b/src/ducks/zkpr.ts
@@ -66,17 +66,13 @@ const setDefaultIdentity = (defaultId: string | null) => {
 
 export const connectZKPR =
   () => async (dispatch: ThunkDispatch<any, any, any>, getState: () => AppRootState) => {
-    console.log('connectZKPR');
     dispatch(setLoading(true));
 
     try {
       if (typeof window.zkpr !== 'undefined') {
-        console.log('ZKPR injected');
         const zkpr: any = window.zkpr;
         const client = await zkpr.connect();
         const zkprClient = new ZKPR(client);
-
-        console.log({ zkprClient });
 
         zkprClient.on('logout', async () => {
           dispatch(disconnectZKPR());
@@ -85,8 +81,6 @@ export const connectZKPR =
 
         zkprClient.on('identityChanged', async idCommitment => {
           dispatch(setIdCommitment(''));
-
-          console.log('identity changed', idCommitment);
 
           if (idCommitment) {
             idCommitment = idCommitment?.startsWith('0x') ? idCommitment : hexlify(idCommitment);
@@ -98,6 +92,7 @@ export const connectZKPR =
 
         localStorage.setItem('ZKPR_CACHED', '1');
         const idCommitment = await zkprClient.getActiveIdentity();
+
         if (idCommitment) {
           // no event fired on connect() so need to set it manually after getActiveIdentity() here
           dispatch(setIdCommitment(idCommitment));
@@ -241,26 +236,11 @@ export class ZKPR {
 
   async getActiveIdentity(): Promise<string | null> {
     const id = await this.client.getActiveIdentity();
-    console.log('client.getActiveIdentity id', id);
     return id ? hexlify(id) : null;
   }
 
   async createIdentity(): Promise<void> {
     await this.client.createIdentity();
-  }
-
-  async getActiveOrCreateIdentity(): Promise<string | null> {
-    const id = await this.getActiveIdentity();
-    if (id !== null) {
-      return id;
-    } else {
-      console.log('no active identity, creating one');
-      const _id = await this.createIdentity();
-      console.log({ _id });
-      const id = await this.getActiveIdentity();
-      console.log({ id });
-      return id;
-    }
   }
 
   async semaphoreProof(

--- a/src/pages/SignupView/index.tsx
+++ b/src/pages/SignupView/index.tsx
@@ -151,7 +151,12 @@ function AccountOptionsView(props: { setViewType: (v: ViewType) => void }): Reac
   const zkpr = useZKPR();
 
   useEffect(() => {
-    if (zkpr) selectOption('incognito');
+    if (zkpr) {
+      selectOption('incognito');
+    } else {
+      // if crypt keeper logout event
+      props.setViewType(ViewType.chooseWallet);
+    }
   }, [zkpr]);
 
   const onNext = useCallback(() => {

--- a/src/pages/SignupView/index.tsx
+++ b/src/pages/SignupView/index.tsx
@@ -303,12 +303,8 @@ function ChooseWalletView(props: { setViewType: (v: ViewType) => void }): ReactE
 
   const connectKeeper = useCallback(async () => {
     disconnect();
-    const id: any = await dispatch(connectZKPR());
-    if (id) {
-      history.push('/');
-    } else {
-      history.push('/signup/interep');
-    }
+    await dispatch(connectZKPR());
+    props.setViewType(ViewType.accountOptions);
   }, []);
 
   useEffect(() => {

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -1,6 +1,12 @@
 import EC from 'elliptic';
 import { Strategy, ZkIdentity } from '@zk-kit/identity';
 
+/**
+ * Convert id commitment big int string from crypt keeper into hex string
+ * @param number
+ */
+export const hexlify = (number: string) => BigInt(`0x${number}`).toString();
+
 export const hexToUintArray = (hex: string): Uint8Array => {
   const a = [];
   for (let i = 0, len = hex.length; i < len; i += 2) {

--- a/src/util/crypto.ts
+++ b/src/util/crypto.ts
@@ -1,12 +1,6 @@
 import EC from 'elliptic';
 import { Strategy, ZkIdentity } from '@zk-kit/identity';
 
-/**
- * Convert id commitment big int string from crypt keeper into hex string
- * @param number
- */
-export const hexlify = (number: string) => BigInt(`0x${number}`).toString();
-
 export const hexToUintArray = (hex: string): Uint8Array => {
   const a = [];
   for (let i = 0, len = hex.length; i < len; i += 2) {


### PR DESCRIPTION
Deal with the scenario where the user wants to connect with cryptkeeper but there is no id commitment stored there yet.  
In this case a new id commitment is created from cryptkeeper and set into zkitter store/state.  

In addition this PR includes several minor refactors in `zkpr.ts` like:
- add types for zkpr client event listeners
- define selector to get default id
- extract logic to set default id in its own function

## Test plan
1. run zkitter ui: `npm run dev`
2. Logged into metamask
3. crypt keeper extension installed without any id commitments yet
4. Add user
5. Crypt Keeper
6. Pop Up should appear asking to unlock and then to create a new id
7. zkitter ui goes to the next screen and display the right id commitment
8. log out of crypt keeper
9. zkitter ui goes back one screen
10. click on crypt keeper again
11. This time the already existed active id is read automatically

[demo video](https://www.loom.com/share/7cd9e7fe6775437d8e853ca8be271fff)

## Next
This PR merges into a `cryptkeeper` dev branch.
I didn't test the full workflow yet. Next we need to use the `provider` value from the cryptkeeper identity too. 